### PR TITLE
BUGFIX: pass the correct param values through to reports 

### DIFF
--- a/javascript/ReportAdmin.js
+++ b/javascript/ReportAdmin.js
@@ -9,7 +9,7 @@
 				var url = $.path.parseUrl(document.location.href).hrefNoSearch, 
 					params = this.find(':input[name^=filters]').serializeArray();
 				params = $.grep(params, function(param) {return (param.value);}); // filter out empty
-				if(params) url = $.path.addSearchParams(url, params);
+				if(params) url = $.path.addSearchParams(url, $.param(params));
 				$('.cms-container').loadPanel(url);
 				return false;
 			}


### PR DESCRIPTION
Fixes an error in the way that parameters are passed into the URL (see https://github.com/silverstripe/silverstripe-cms/pull/956)
