### PR TITLE
FIX: Remove referencies to Object::$class

### DIFF
--- a/code/Report.php
+++ b/code/Report.php
@@ -196,7 +196,8 @@ class Report extends ViewableData
     {
         $sourceRecords = $this->sourceRecords($params, null, null);
         if (!$sourceRecords instanceof SS_List) {
-            user_error($this->class."::sourceRecords does not return an SS_List", E_USER_NOTICE);
+
+            user_error(get_class($this) . "::sourceRecords does not return an SS_List", E_USER_NOTICE);
             return "-1";
         }
         return $sourceRecords->count();

--- a/code/SideReport.php
+++ b/code/SideReport.php
@@ -43,7 +43,7 @@ class SideReportView extends ViewableData
         $columns = $this->report->columns();
 
         if ($records && $records->Count()) {
-            $result = "<ul class=\"$this->class\">\n";
+            $result = "<ul class=\"" . get_class($this) . "\">\n";
 
             foreach ($records as $record) {
                 $result .= "<li>\n";

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -31,7 +31,7 @@ class ReportTest extends SapphireTest
         $reports = Report::get_reports();
         $reportNames = array();
         foreach ($reports as $report) {
-            $reportNames[] = $report->class;
+            $reportNames[] = get_class($report);
         }
         $this->assertContains('ReportTest_FakeTest', $reportNames, 'ReportTest_FakeTest is in reports list');
 
@@ -41,7 +41,7 @@ class ReportTest extends SapphireTest
         $reports = Report::get_reports();
         $reportNames = array();
         foreach ($reports as $report) {
-            $reportNames[] = $report->class;
+            $reportNames[] = get_class($report);
         }
         $this->assertNotContains('ReportTest_FakeTest', $reportNames, 'ReportTest_FakeTest is NOT in reports list');
 
@@ -51,7 +51,7 @@ class ReportTest extends SapphireTest
         $reports = Report::get_reports();
         $reportNames = array();
         foreach ($reports as $report) {
-            $reportNames[] = $report->class;
+            $reportNames[] = get_class($report);
         }
         $this->assertNotContains('ReportTest_FakeTest', $reportNames, 'ReportTest_FakeTest is NOT in reports list');
         $this->assertNotContains('ReportTest_FakeTest2', $reportNames, 'ReportTest_FakeTest2 is NOT in reports list');
@@ -62,7 +62,7 @@ class ReportTest extends SapphireTest
         $reports = Report::get_reports();
         $reportNames = array();
         foreach ($reports as $report) {
-            $reportNames[] = $report->class;
+            $reportNames[] = get_class($report);
         }
         $this->assertNotContains('ReportTest_FakeTest_Abstract',
             $reportNames,


### PR DESCRIPTION
This property is being deprecated in SS4 and so this removes references to it.