### PR TITLE
FIX: Relax PHP version requirement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.3,<7",
+		"php": ">=5.3.3,<7.2",
 		"silverstripe/framework": "~3.3"
 	},
 	"extra": {


### PR DESCRIPTION
PHP7 support for SS3 is currently under development and the safest 
approach is to fix this module first.

See https://github.com/silverstripe/silverstripe-framework/pull/6771