### PR TITLE
New style travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,40 @@
-# See https://github.com/silverstripe-labs/silverstripe-travis-support for setup details
+language: php
 
 sudo: false
 
-language: php
+env:
+  global:
+    - COMPOSER_ROOT_VERSION=1.0.x-dev
 
 env:
   global:
     - CORE_RELEASE=master
 
 matrix:
+  fast_finish: true
   include:
     - php: 5.6
-      env: DB=MYSQL PHPCS_TEST=1
+      env: DB=MYSQL PHPUNIT_TEST=1 PHPCS_TEST=1
     - php: 7.0
-      env: DB=PGSQL
+      env: DB=MYSQL PHPUNIT_TEST=1
     - php: 7.1.2
-      env: DB=MYSQL
+      env: DB=MYSQL PDO=1 PHPUNIT_COVERAGE_TEST=1
 
 before_script:
   - composer validate
   - composer self-update || true
-  - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
-  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
-  - cd ~/builds/ss
-  - composer install
+  - "if [ \"$PHPCS_TEST\" = \"1\" ]; then pyrus install pear/PHP_CodeSniffer; fi"
+  - phpenv rehash
+  - phpenv config-rm xdebug.ini
+  - composer validate
+  - composer install --prefer-dist
+  - composer require --no-update --prefer-dist silverstripe/admin:1.0.x-dev silverstripe/framework:4.0.x-dev silverstripe/versioned:1.0.x-dev silverstripe/config:1.0.x-dev silverstripe/assets:1.0.x-dev --prefer-dist
+  - composer update
 
 script:
-  - vendor/bin/phpunit reports/tests
-  - if [[ $PHPCS_TEST ]]; then (cd reports && composer run-script lint); fi
+  - "if [ \"$PHPUNIT_TEST\" = \"1\" ]; then vendor/bin/phpunit; fi"
+  - "if [ \"$PHPCS_TEST\" = \"1\" ]; then composer run-script lint; fi"
+  - "if [ \"$PHPUNIT_COVERAGE_TEST\" = \"1\" ]; then vendor/bin/phpunit --coverage-clover=coverage.xml; fi"
+
+after_success:
+  - "if [ \"$PHPUNIT_COVERAGE_TEST\" = \"1\" ]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi"

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,11 @@
     }
   ],
   "require": {
-    "silverstripe/framework": "^4.0@dev",
-    "silverstripe/admin": "^1.0@dev"
+    "silverstripe/framework": "4.0.x-dev",
+    "silverstripe/admin": "1.0.x-dev",
+    "silverstripe/versioned": "1.0.x-dev",
+    "silverstripe/config": "1.0.x-dev",
+    "silverstripe/assets": "1.0.x-dev"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7"
@@ -36,5 +39,7 @@
   "scripts": {
     "lint": "phpcs code/ tests/",
     "lint-clean": "phpcbf code/ tests/"
-  }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,16 @@
+<phpunit bootstrap="framework/tests/bootstrap.php" colors="true">
+
+    <testsuite name="Default">
+        <directory>tests</directory>
+    </testsuite>
+
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">.</directory>
+            <exclude>
+                <directory suffix=".php">tests/</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+</phpunit>

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -2,10 +2,9 @@
 
 namespace SilverStripe\Reports\Tests;
 
-use SilverStripe\Dev\SapphireTest;
-use SilverStripe\Forms\GridField\GridField;
-use SilverStripe\Forms\GridField\GridFieldDataColumns;
 use SilverStripe\Reports\Report;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\GridField\GridFieldDataColumns;
 use SilverStripe\Reports\Tests\ReportTest\FakeObject;
 use SilverStripe\Reports\Tests\ReportTest\FakeTest;
 use SilverStripe\Reports\Tests\ReportTest\FakeTest2;

--- a/tests/ReportTest_FakeObject.php
+++ b/tests/ReportTest_FakeObject.php
@@ -1,0 +1,39 @@
+<?php
+namespace SilverStripe\Reports\Tests;
+
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\CMSPreviewable;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Control\Controller;
+
+class ReportTest_FakeObject extends DataObject implements CMSPreviewable, TestOnly
+{
+
+    private static $db = array(
+        'Title' => 'Varchar'
+    );
+
+    /**
+     * @return String Absolute URL to the end-user view for this record.
+     * Example: http://mysite.com/my-record
+     */
+    public function Link()
+    {
+        return Controller::join_links('dummy-link', $this->ID);
+    }
+
+    public function CMSEditLink()
+    {
+        return Controller::join_links('dummy-edit-link', $this->ID);
+    }
+
+    public function PreviewLink($action = null)
+    {
+        return false;
+    }
+
+    public function getMimeType()
+    {
+        return 'text/html';
+    }
+}

--- a/tests/ReportTest_FakeTest.php
+++ b/tests/ReportTest_FakeTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace SilverStripe\Reports\Tests;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\Reports\Report;
+
+/**
+ * @package reports
+ * @subpackage tests
+ */
+class ReportTest_FakeTest extends Report implements TestOnly
+{
+    public function title()
+    {
+        return 'Report title';
+    }
+    public function columns()
+    {
+        return array(
+            "Title" => array(
+                "title" => "Page Title",
+                "link" => true,
+            )
+        );
+    }
+    public function sourceRecords($params, $sort, $limit)
+    {
+        return new ArrayList();
+    }
+
+    public function sort()
+    {
+        return 100;
+    }
+}

--- a/tests/ReportTest_FakeTest2.php
+++ b/tests/ReportTest_FakeTest2.php
@@ -1,0 +1,35 @@
+<?php
+namespace SilverStripe\Reports\Tests;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\Reports\Report;
+
+/**
+ * @package reports
+ * @subpackage tests
+ */
+class ReportTest_FakeTest2 extends Report implements TestOnly
+{
+    public function title()
+    {
+        return 'Report title 2';
+    }
+    public function columns()
+    {
+        return array(
+            "Title" => array(
+                "title" => "Page Title 2"
+            )
+        );
+    }
+    public function sourceRecords($params, $sort, $limit)
+    {
+        return new ArrayList();
+    }
+
+    public function sort()
+    {
+        return 98;
+    }
+}

--- a/tests/ReportTest_FakeTest_Abstract.php
+++ b/tests/ReportTest_FakeTest_Abstract.php
@@ -1,0 +1,37 @@
+<?php
+namespace SilverStripe\Reports\Tests;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\Reports\Report;
+
+/**
+ * @package reports
+ * @subpackage tests
+ */
+abstract class ReportTest_FakeTest_Abstract extends Report implements TestOnly
+{
+
+    public function title()
+    {
+        return 'Report title Abstract';
+    }
+
+    public function columns()
+    {
+        return array(
+            "Title" => array(
+                "title" => "Page Title Abstract"
+            )
+        );
+    }
+    public function sourceRecords($params, $sort, $limit)
+    {
+        return new ArrayList();
+    }
+
+    public function sort()
+    {
+        return 5;
+    }
+}


### PR DESCRIPTION
- Removed PHP 5.5. build (no longer supported)
- Removed PG and SQLite tests (tested through installer nightly)
- Added code coverage and linting tests
- Fixed linting errors