### PR TITLE
FIX: Drop php5.5, add php7.1, simplify build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,14 @@ sudo: false
 
 language: php
 
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-
-env:
-  - DB=MYSQL CORE_RELEASE=master
-
 matrix:
   include:
     - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=master
+      env: DB=MYSQL CORE_RELEASE=master
     - php: 7.0
       env: DB=PGSQL CORE_RELEASE=master
+    - php: 7.1.2
+      env: DB=MYSQL CORE_RELEASE=master
 
 before_script:
   - composer self-update || true


### PR DESCRIPTION
SS4 no longer supports PHP 5.5 so I’ve dropped it. In addition I’ve
reduced the double-up of builds as we don’t need so many. And I’ve
added PHP 7.1