### PR TITLE
Remove empty toolbar header from reports list

### DIFF
--- a/code/ReportAdmin.php
+++ b/code/ReportAdmin.php
@@ -219,7 +219,6 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider
             // List all reports
             $fields = new FieldList();
             $gridFieldConfig = GridFieldConfig::create()->addComponents(
-                new GridFieldToolbarHeader(),
                 new GridFieldSortableHeader(),
                 new GridFieldDataColumns(),
                 new GridFieldFooter()


### PR DESCRIPTION
Remove empty space above list. See https://github.com/silverstripe/silverstripe-cms/issues/981. Confirmed this doesn't affect the titles of individual reports.

Before:

![image](https://cloud.githubusercontent.com/assets/111025/26197458/5738a8c8-3c16-11e7-82c4-2bbded51640e.png)


After:

![image](https://cloud.githubusercontent.com/assets/111025/26197440/49247762-3c16-11e7-8f3a-168796055bde.png)
