### PR TITLE
Adds missing PreviewPanel template file to the main reports folder

### DIFF
--- a/templates/SilverStripe/Reports/Includes/ReportAdmin_PreviewPanel.ss
+++ b/templates/SilverStripe/Reports/Includes/ReportAdmin_PreviewPanel.ss
@@ -1,0 +1,14 @@
+<div class="cms-preview fill-height flexbox-area-grow" data-layout-type="border">
+	<div class="panel flexbox-area-grow fill-height">
+		<div class="preview-note"><span><!-- --></span><%t SilverStripe\CMS\Controllers\CMSPageHistoryController.PREVIEW 'Website preview' %></div>
+		<div class="preview__device">
+			<div class="preview-device-outer">
+				<div class="preview-device-inner">
+					<iframe src="about:blank" class="center" name="cms-preview-iframe"></iframe>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="toolbar toolbar--south cms-content-controls cms-preview-controls"></div>
+	<div class="cms-preview-overlay ui-widget-overlay-light"></div>
+</div>


### PR DESCRIPTION
See Issue 1841 - BUG Navigating to a page from reports section loads broken CMSMain view