### PR TITLE
Remove php7 test suite as its pointless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7.0
 
 env:
   - DB=MYSQL CORE_RELEASE=3.3
@@ -22,8 +21,6 @@ matrix:
       env: DB=PGSQL CORE_RELEASE=3
     - php: 5.6
       env: DB=PGSQL CORE_RELEASE=3.2
-  allow_failures:
-    - php: 7.0
 
 before_script:
   - composer self-update || true


### PR DESCRIPTION
Our constraint (for 3.5) explicitly stops PHP7 working.

This test suite is pointless.