### PR TITLE
FIX Filter var can be returned correctly from get variables as a fallback

### DIFF
--- a/code/Report.php
+++ b/code/Report.php
@@ -349,7 +349,7 @@ class Report extends ViewableData
         if (Injector::inst()->has(HTTPRequest::class)) {
             /** @var HTTPRequest $request */
             $request = Injector::inst()->get(HTTPRequest::class);
-            $params = $request->param('filters') ?: [];
+            $params = $request->param('filters') ?: $request->getVar('filters') ?: [];
         }
         $items = $this->sourceRecords($params, null, null);
 


### PR DESCRIPTION
In CWP 2.1.0-rc1 the "elements in use report" cannot be filtered by elemental class type because this is not checking the `?filters[ClassName...` var in the URL. This adds a fallback to check for it there as well as in params.