### PR TITLE
FIX Use requestVar() to include post vars as well as get vars

### DIFF
--- a/code/Report.php
+++ b/code/Report.php
@@ -349,7 +349,7 @@ class Report extends ViewableData
         if (Injector::inst()->has(HTTPRequest::class)) {
             /** @var HTTPRequest $request */
             $request = Injector::inst()->get(HTTPRequest::class);
-            $params = $request->param('filters') ?: $request->getVar('filters') ?: [];
+            $params = $request->param('filters') ?: $request->requestVar('filters') ?: [];
         }
         $items = $this->sourceRecords($params, null, null);
 


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-contentreview/issues/103

GridField pagination provides filter vars in the post data body, so this fix aligns more closely to the SS3 version which uses $_REQUEST, and allows for filter params to come from both get and post vars