### PR TITLE
Update Travis config to include PHP 7.4 build (3.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,22 @@
 
 sudo: false
 
-dist: precise
+dist: trusty
 
 language: php
-
-php:
-  - 5.3
-  - 5.4
-  - 5.5
 
 env:
   - DB=MYSQL CORE_RELEASE=3.6
 
 matrix:
   include:
+    - php: 5.4
+    - php: 5.5
     - php: 5.6
       env: DB=PGSQL CORE_RELEASE=3
     - php: 5.6
       env: DB=PGSQL CORE_RELEASE=3.6
     - php: 7.1
-      env: DB=MYSQL CORE_RELEASE=3.6
 
 before_script:
   - composer self-update || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ dist: trusty
 language: php
 
 env:
-  - DB=MYSQL CORE_RELEASE=3.6
+  - DB=MYSQL CORE_RELEASE=3.7
 
 matrix:
   include:
@@ -16,8 +16,12 @@ matrix:
     - php: 5.6
       env: DB=PGSQL CORE_RELEASE=3
     - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=3.6
+      env: DB=PGSQL CORE_RELEASE=3.7
     - php: 7.1
+    - php: 7.4
+      dist: xenial
+      services:
+        - mysql
 
 before_script:
   - composer self-update || true


### PR DESCRIPTION
Includes upgrade to `trusty`, and removal of PHP 5.3 build.