### PR TITLE
Simplify $member check

### DIFF
--- a/code/ReportAdmin.php
+++ b/code/ReportAdmin.php
@@ -79,7 +79,7 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider
      */
     public function canView($member = null)
     {
-        if (!$member && $member !== false) {
+        if (!$member) {
             $member = Security::getCurrentUser();
         }
 


### PR DESCRIPTION
`!$member` is a superset of `$member !== false`: no need to check for both.