### PR TITLE
FIX Apply urldecode to querystring vars

### DIFF
--- a/code/ReportAdmin.php
+++ b/code/ReportAdmin.php
@@ -251,7 +251,11 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider
         $actions = new FieldList();
         $form = new Form($this, "EditForm", $fields, $actions);
         $form->addExtraClass('panel panel--padded panel--scrollable cms-edit-form cms-panel-padded' . $this->BaseCSSClasses());
-        $form->loadDataFrom($this->request->getVars());
+        $vars = $this->request->getVars();
+        array_walk_recursive($vars, function (&$value) {
+            $value = urldecode($value);
+        });
+        $form->loadDataFrom($vars);
 
         $this->extend('updateEditForm', $form);
 


### PR DESCRIPTION
Fix for https://github.com/silverstripe/silverstripe-reports/issues/133

I'm unsure about this approach because while it means that the space character can now be properly used in a filter value, the plus character can no longer be.  It does seem pretty likely that space would be a far more used character than plus though

The developer who creates the custom report is required to put something like the following in their report for space to work (whether or not we merge this PR).  Again, it has the same limitation that the space character can be used as part of a filter but not the plus character.

```php
    public function sourceRecords($params = null)
    {
        array_walk_recursive($params, function(&$value) {
            $value = urldecode($value);
        });
        return MyModel::get()->filter($params);
    }
```

Sample code that can be used to test this PR:

MyModel.php
```php
<?php

use SilverStripe\ORM\DataObject;

class MyModel extends DataObject
{
    private static $db = [
        'MyField' => 'Varchar'
    ];

    public function requireDefaultRecords()
    {
        parent::requireDefaultRecords();
        if (self::get()->count() > 0) {
            return;
        }
        $values = ['X', 'Y', 'A B', 'A+B'];
        foreach ($values as $value) {
            $record = self::create();
            $record->MyField = $value;
            $record->write();
        }
    }
}

```

MyReport.php
```php
<?php

use SilverStripe\Forms\FieldList;
use SilverStripe\Forms\TextField;
use SilverStripe\Reports\Report;

class MyReport extends Report
{
    public function title()
    {
        return 'My report';
    }

    public function sourceRecords($params = null)
    {
        array_walk_recursive($params, function(&$value) {
            $value = urldecode($value);
        });
        return MyModel::get()->filter($params);
    }

    public function columns()
    {
        return ['MyField' => 'MyField'];
    }

    public function parameterFields()
    {
        return new FieldList(
            new TextField('MyField', 'MyField')
        );
    }
}

```

