### PR TITLE
ENH Add configuration to cap report counts for large datasets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ The reports section will not show up in the CMS if:
  * There are no reports to show
  * The logged in user does not have permission to view any reports
 
+For large datasets, the reports section may take a long time to load, since each report is getting a count of the items it contains to display next to the title.
+
+To mitigate this issue, there is a cap on the number of items that will be counted per report. This is set at 10,000 items by default, but can be configured using the `limit_count_in_overview` configuration variable. Setting this to `null` will result in showing the actual count regardless of how many items there are.
+
+```yml
+SilverStripe\Reports\Report:
+  limit_count_in_overview: 500
+```
+Note that some reports may have overridden the `getCount` method, and for those reports this may not apply.
+
 ## Links ##
 
  * [License](./LICENSE)

--- a/code/ReportAdmin.php
+++ b/code/ReportAdmin.php
@@ -242,7 +242,7 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider
             ));
 
             $columns->setFieldFormatting(array(
-                    'title' => '<a href=\"$Link\" class=\"grid-field__link-block\">$value ($Count)</a>'
+                    'title' => '<a href=\"$Link\" class=\"grid-field__link-block\">$value ($CountForOverview)</a>'
                 ));
             $gridField->addExtraClass('all-reports-gridfield');
             $fields->push($gridField);

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -114,4 +114,20 @@ class ReportTest extends SapphireTest
             $titleContent
         );
     }
+
+    public function testCountForOverview()
+    {
+        $report = new ReportTest\FakeTest3();
+
+        // Count is limited to 10000 by default
+        $this->assertEquals('10000+', $report->getCountForOverview());
+
+        // Count is limited as per configuration
+        Config::modify()->set(ReportTest\FakeTest3::class, 'limit_count_in_overview', 15);
+        $this->assertEquals('15+', $report->getCountForOverview());
+
+        // A null limit displays the full count
+        Config::modify()->set(ReportTest\FakeTest3::class, 'limit_count_in_overview', null);
+        $this->assertEquals('15000', $report->getCountForOverview());
+    }
 }

--- a/tests/ReportTest/FakeTest3.php
+++ b/tests/ReportTest/FakeTest3.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SilverStripe\Reports\Tests\ReportTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\Reports\Report;
+
+class FakeTest3 extends Report implements TestOnly
+{
+    public function sourceRecords($params, $sort, $limit)
+    {
+        return new ArrayList(range(1, 15000));
+    }
+}


### PR DESCRIPTION
Fixes #105

Opted not to return the result from `getCount()` directly since the PHPDoc says this returns an int (even though it technically already returns a string if the report isn't set up correctly...)