### PR TITLE
ENH Prefer dependency injection for GridFieldComponents

### DIFF
--- a/code/Report.php
+++ b/code/Report.php
@@ -389,12 +389,12 @@ class Report extends ViewableData
         $items = $this->sourceRecords($params, null, null);
 
         $gridFieldConfig = GridFieldConfig::create()->addComponents(
-            new GridFieldButtonRow('before'),
-            new GridFieldPrintButton('buttons-before-left'),
-            new GridFieldExportButton('buttons-before-left'),
-            new GridFieldSortableHeader(),
-            new GridFieldDataColumns(),
-            new GridFieldPaginator()
+            GridFieldButtonRow::create('before'),
+            GridFieldPrintButton::create('buttons-before-left'),
+            GridFieldExportButton::create('buttons-before-left'),
+            GridFieldSortableHeader::create(),
+            GridFieldDataColumns::create(),
+            GridFieldPaginator::create()
         );
         /** @var GridField $gridField */
         $gridField = GridField::create('Report', null, $items, $gridFieldConfig);

--- a/code/ReportAdmin.php
+++ b/code/ReportAdmin.php
@@ -230,11 +230,11 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider
             // List all reports
             $fields = new FieldList();
             $gridFieldConfig = GridFieldConfig::create()->addComponents(
-                new GridFieldSortableHeader(),
-                new GridFieldDataColumns(),
-                new GridFieldFooter()
+                GridFieldSortableHeader::create(),
+                GridFieldDataColumns::create(),
+                GridFieldFooter::create()
             );
-            $gridField = new GridField('Reports', false, $this->Reports(), $gridFieldConfig);
+            $gridField = GridField::create('Reports', false, $this->Reports(), $gridFieldConfig);
             /** @var GridFieldDataColumns $columns */
             $columns = $gridField->getConfig()->getComponentByType('SilverStripe\\Forms\\GridField\\GridFieldDataColumns');
             $columns->setDisplayFields(array(

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "^4.10",
+        "silverstripe/framework": "^4.11",
         "silverstripe/admin": "^1.6@dev",
         "silverstripe/versioned": "^1.6@dev",
         "silverstripe/config": "^1.0@dev",


### PR DESCRIPTION
GridFieldComponents packaged with silverstripe/framework are injectable as of 4.11.0 (see silverstripe/silverstripe-framework#10204)
Explicitly invoking the injector here instead of using create() allows backwards compatability with framework < 4.11.0 while ensuring dependency injection is still used from 4.11.0 onwards.
See silverstripe/silverstripe-admin#1286 for (brief) discussion of this approach vs using `::create()`.