### PR TITLE
Rescue Master Branch PR: PSR12 compliance

### DIFF
--- a/code/Report.php
+++ b/code/Report.php
@@ -61,7 +61,8 @@ use SilverStripe\View\ViewableData;
  * Right now, all subclasses of SS_Report will be shown in the ReportAdmin. In SS3 there is only
  * one place where reports can go, so this class is greatly simplifed from its version in SS2.
  *
- * @method SS_List|DataList sourceRecords($params = [], $sort = null, $limit = null) List of records to show for this report
+ * @method SS_List|DataList sourceRecords($params = [], $sort = null, $limit = null)
+ *      List of records to show for this report
  */
 class Report extends ViewableData
 {
@@ -158,7 +159,8 @@ class Report extends ViewableData
     {
         if (!$this->hasMethod('sourceRecords')) {
             throw new \RuntimeException(
-                'Please override sourceQuery()/sourceRecords() and columns() or, if necessary, override getReportField()'
+                'Please override sourceQuery()/sourceRecords() and columns() or, '
+                . 'if necessary, override getReportField()'
             );
         }
 
@@ -353,7 +355,10 @@ class Report extends ViewableData
             }
 
             // Add a search button
-            $formAction = FormAction::create('updatereport', _t('SilverStripe\\Forms\\GridField\\GridField.Filter', 'Filter'));
+            $formAction = FormAction::create(
+                'updatereport',
+                _t('SilverStripe\\Forms\\GridField\\GridField.Filter', 'Filter')
+            );
             $formAction->addExtraClass('btn-primary mb-4');
 
             $fields->push($formAction);

--- a/code/ReportAdmin.php
+++ b/code/ReportAdmin.php
@@ -181,13 +181,13 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider
             }
 
             //build breadcrumb trail to the current report
-            $items->push(new ArrayData(array(
+            $items->push(ArrayData::create([
                 'Title' => $report->title(),
                 'Link' => Controller::join_links(
                     $this->Link(),
-                    '?' . http_build_query(array('q' => $this->request->requestVar('q')))
+                    '?' . http_build_query(['q' => $this->request->requestVar('q')])
                 )
-            )));
+            ]));
         }
 
         return $items;
@@ -236,7 +236,8 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider
             );
             $gridField = GridField::create('Reports', false, $this->Reports(), $gridFieldConfig);
             /** @var GridFieldDataColumns $columns */
-            $columns = $gridField->getConfig()->getComponentByType('SilverStripe\\Forms\\GridField\\GridFieldDataColumns');
+            $columns = $gridField->getConfig()
+                ->getComponentByType('SilverStripe\\Forms\\GridField\\GridFieldDataColumns');
             $columns->setDisplayFields(array(
                 'title' => _t('SilverStripe\\Reports\\ReportAdmin.ReportTitle', 'Title'),
             ));
@@ -250,7 +251,9 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider
 
         $actions = new FieldList();
         $form = new Form($this, "EditForm", $fields, $actions);
-        $form->addExtraClass('panel panel--padded panel--scrollable cms-edit-form cms-panel-padded' . $this->BaseCSSClasses());
+        $form->addExtraClass(
+            'panel panel--padded panel--scrollable cms-edit-form cms-panel-padded' . $this->BaseCSSClasses()
+        );
         $form->loadDataFrom($this->request->getVars());
 
         $this->extend('updateEditForm', $form);

--- a/code/ReportWrapper.php
+++ b/code/ReportWrapper.php
@@ -21,7 +21,7 @@ abstract class ReportWrapper extends Report
 
     public function __construct($baseReport)
     {
-        $this->baseReport = is_string($baseReport) ? new $baseReport : $baseReport;
+        $this->baseReport = is_string($baseReport) ? new $baseReport() : $baseReport;
         $this->dataClass = $this->baseReport->dataClass();
         parent::__construct();
     }

--- a/code/ReportWrapper.php
+++ b/code/ReportWrapper.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\Reports;
 
+use SilverStripe\Core\Injector\Injector;
+
 /**
  * SS_ReportWrapper is a base class for creating report wappers.
  *
@@ -21,7 +23,7 @@ abstract class ReportWrapper extends Report
 
     public function __construct($baseReport)
     {
-        $this->baseReport = is_string($baseReport) ? new $baseReport() : $baseReport;
+        $this->baseReport = is_string($baseReport) ? Injector::inst()->create($baseReport) : $baseReport;
         $this->dataClass = $this->baseReport->dataClass();
         parent::__construct();
     }

--- a/code/SideReportView.php
+++ b/code/SideReportView.php
@@ -11,8 +11,8 @@ use SilverStripe\View\ViewableData;
  */
 class SideReportView extends ViewableData
 {
-
-    protected $controller, $report;
+    protected $controller;
+    protected $report;
     protected $parameters;
 
     public function __construct($controller, $report)

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,20 +5,9 @@
 	<file>code</file>
 	<file>tests</file>
 
-	<!-- base rules are PSR-2 -->
-	<rule ref="PSR2" >
+	<!-- base rules are PSR-12 -->
+	<rule ref="PSR12" >
 		<!-- Current exclusions -->
-		<exclude name="PSR1.Methods.CamelCapsMethodName" />
-		<exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
-		<exclude name="PSR2.Classes.PropertyDeclaration" />
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration" /> <!-- causes php notice while linting -->
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenercase" />
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenerdefault" />
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.TerminatingComment" />
-		<exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
-		<exclude name="Squiz.Scope.MethodScope" />
-		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
-		<exclude name="Generic.Files.LineLength.TooLong" />
-		<exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
+		<exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
 	</rule>
 </ruleset>

--- a/tests/ReportAdminTest.php
+++ b/tests/ReportAdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace SilverStripe\Reports\Tests;
 
 use ReflectionClass;

--- a/tests/ReportAdminTest/FakeReport.php
+++ b/tests/ReportAdminTest/FakeReport.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace SilverStripe\Reports\Tests\ReportAdminTest;
 
 use SilverStripe\Dev\TestOnly;

--- a/tests/ReportAdminTest/FakeReport2.php
+++ b/tests/ReportAdminTest/FakeReport2.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace SilverStripe\Reports\Tests\ReportAdminTest;
 
 use SilverStripe\Control\Controller;

--- a/tests/ReportTest/FakeTestAbstract.php
+++ b/tests/ReportTest/FakeTestAbstract.php
@@ -8,7 +8,6 @@ use SilverStripe\Reports\Report;
 
 abstract class FakeTestAbstract extends Report implements TestOnly
 {
-
     public function title()
     {
         return 'Report title Abstract';


### PR DESCRIPTION
Rescues https://github.com/silverstripe/silverstripe-reports/pull/115

Targetting `4` since there are no API changes. This allows both major lines to benefit and reduces merge-up pain.
Excludes the swap from `code/` to `src/` to reduce merge-up pain - there isn't really much (if any) benefit to making that change. If someone reviewing this _does_ want that change included, I will do it as a separate PR targetting `5` just to be safe.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350