### PR TITLE
MNT Don't expect trailing slash in tests

### DIFF
--- a/tests/ReportAdminTest.php
+++ b/tests/ReportAdminTest.php
@@ -23,7 +23,7 @@ class ReportAdminTest extends SapphireTest
         $this->assertCount(2, $breadcrumbs);
         $map = $breadcrumbs[0]->toMap();
         $this->assertSame('Reports', $map['Title']);
-        $this->assertSame('admin/reports/', $map['Link']);
+        $this->assertSame('admin/reports', $map['Link']);
 
         $map = $breadcrumbs[1]->toMap();
         $this->assertSame('Fake report', $map['Title']);
@@ -36,7 +36,7 @@ class ReportAdminTest extends SapphireTest
 
         $map = $breadcrumbs[0]->toMap();
         $this->assertSame('Reports', $map['Title']);
-        $this->assertSame('admin/reports/', $map['Link']);
+        $this->assertSame('admin/reports', $map['Link']);
 
         $map = $breadcrumbs[1]->toMap();
         $this->assertSame('Fake report title', $map['Title']);


### PR DESCRIPTION
https://github.com/silverstripe/silverstripe-framework/pull/10538 makes various methods _not_ include a trailing slash by default. This PR updates relevant tests to not expect trailing slashes.

## Parent issue
- https://github.com/silverstripe/silverstripe-cms/issues/2780