### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "4.13.x-dev",
-        "silverstripe/admin": "1.13.x-dev",
-        "silverstripe/versioned": "1.13.x-dev",
-        "silverstripe/config": "1.6.x-dev",
-        "silverstripe/assets": "1.13.x-dev",
+        "silverstripe/framework": "^4.11",
+        "silverstripe/admin": "^1.6@dev",
+        "silverstripe/versioned": "^1.6@dev",
+        "silverstripe/config": "^1.0@dev",
+        "silverstripe/assets": "^1.6@dev",
         "silverstripe/vendor-plugin": "^1"
     },
     "require-dev": {


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

See https://github.com/silverstripe/silverstripe-reports/commit/2bf6bc1a9cebe8ade761607b77cee0eb34feb95a

## Issue
- https://github.com/silverstripe/.github/issues/33