### PR TITLE
FIX broken URL builder when using MultiSelectFields as parameters

### DIFF
--- a/javascript/ReportAdmin.js
+++ b/javascript/ReportAdmin.js
@@ -2,17 +2,32 @@
  * File: ReportAdmin.js
  */
 
-(function($) {
-	$.entwine('ss', function($){
-		$('.ReportAdmin .cms-edit-form').entwine({
-			onsubmit: function(e) {
-				var url = $.path.parseUrl(document.location.href).hrefNoSearch,
-					params = this.find(':input[name^=filters]').serializeArray();
-				params = $.grep(params, function(param) {return (param.value);}); // filter out empty
-				if(params) url = $.path.addSearchParams(url, $.param(params));
-				$('.cms-container').loadPanel(url);
-				return false;
-			}
-		});
-	});
+(function ($) {
+  $.entwine("ss", function ($) {
+    $(".ReportAdmin .cms-edit-form").entwine({
+      onsubmit: function (e) {
+        let url = $.path.parseUrl(document.location.href).hrefNoSearch;
+        let params = this.find(":input[name^=filters]").serializeArray();
+
+        try {
+          params = $.grep(params, function (param) {
+            // filter out empty
+            return param.value;
+          });
+
+          // convert params to a query string
+          params = $.param(params);
+
+          // append query string to url
+          url += "?" + params;
+
+          $(".cms-container").loadPanel(url);
+        } catch (err) {
+          console.error(err);
+        }
+
+        return false;
+      },
+    });
+  });
 })(jQuery);


### PR DESCRIPTION
When using `MultiSelectField` instances (or any field name that has the [] syntax - I also tested with `TagField` to confirm it was broken) the current implementation only pushes the final value into the URL rather than all instances of them.

Repo example if you want to test pre / post. You'll note on current `4` only 1 value of ListboxField is saved.

```php
<?php

use SilverStripe\Forms\FieldList;
use SilverStripe\Forms\ListboxField;
use SilverStripe\Reports\Report;

class TestReport extends Report
{
    public function title()
    {
        return 'Report';
    }


    public function parameterFields()
    {
        return FieldList::create([
            ListboxField::create('PageID', 'Page', Page::get())
        ]);
    }


    public function sourceRecords($params = [], $sort = null, $limit = null)
    {
        $pages = Page::get();

        if (isset($params['PageID'])) {
            $pages = $pages->filter('ID', $params['PageID']);
        }

        return $pages;
    }
}
```