### PR TITLE
ENH Reports list filtering and pagination.

### DIFF
--- a/code/ReportAdmin.php
+++ b/code/ReportAdmin.php
@@ -7,12 +7,19 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldButtonRow;
 use SilverStripe\Forms\GridField\GridFieldConfig;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
-use SilverStripe\Forms\GridField\GridFieldFooter;
+use SilverStripe\Forms\GridField\GridFieldFilterHeader;
+use SilverStripe\Forms\GridField\GridFieldPageCount;
+use SilverStripe\Forms\GridField\GridFieldPaginator;
 use SilverStripe\Forms\GridField\GridFieldSortableHeader;
+use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
+use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\Filters\PartialMatchFilter;
+use SilverStripe\ORM\Search\BasicSearchContext;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\PermissionProvider;
@@ -104,13 +111,18 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider
      */
     public function Reports()
     {
-        $output = new ArrayList();
+        $output = ArrayList::create();
         foreach (Report::get_reports() as $report) {
             if ($report->canView()) {
                 $output->push($report);
             }
         }
-        return $output;
+
+        return $output
+            // Provide a good default for the reports order, otherwise this will be using sort by namespace
+            ->sort('Title', 'ASC')
+            // Provide a good default for the data class, otherwise this will use the class of the first item in the list
+            ->setDataClass(Report::class);
     }
 
     public function handleAction($request, $action)
@@ -227,28 +239,60 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider
             $fields = $report->getCMSFields();
         } else {
             // List all reports
-            $fields = new FieldList();
+            $fields = FieldList::create();
             $gridFieldConfig = GridFieldConfig::create()->addComponents(
+                // This is a container component that is required by filter header component
+                GridFieldButtonRow::create('before'),
+                $filterHeader = GridFieldFilterHeader::create(),
                 GridFieldSortableHeader::create(),
-                GridFieldDataColumns::create(),
-                GridFieldFooter::create()
+                $columns = GridFieldDataColumns::create(),
+                GridFieldPageCount::create(),
+                GridFieldPaginator::create()
             );
+
+            // Configure the filter header filter search form
+            $generalField = BasicSearchContext::config()->get('general_search_field_name');
+            $searchFieldList = FieldList::create([
+                HiddenField::create($generalField),
+                TextField::create('Title'),
+                TextField::create('Description'),
+            ]);
+
+            $searchContext = BasicSearchContext::create(Report::class);
+            $searchContext->setFields($searchFieldList);
+
+            // Setup filter configuration - partial match with case-insensitive modifier
+            $filters = [
+                'Title',
+                'Description',
+            ];
+
+            foreach ($filters as $fieldName) {
+                $fieldFilter = PartialMatchFilter::create($fieldName);
+                $fieldFilter->setModifiers([
+                    // We want case-insensitive match to be consistent with other areas of the CMS
+                    'nocase',
+                ]);
+                $searchContext->addFilter($fieldFilter);
+            }
+
+            $filterHeader->setSearchContext($searchContext);
+
             $gridField = GridField::create('Reports', false, $this->Reports(), $gridFieldConfig);
-            $columns = $gridField->getConfig()
-                ->getComponentByType(GridFieldDataColumns::class);
             $columns->setDisplayFields(array(
                 'title' => _t('SilverStripe\\Reports\\ReportAdmin.ReportTitle', 'Title'),
+                'description' => _t('SilverStripe\\Reports\\ReportAdmin.ReportDescription', 'Description'),
             ));
 
-            $columns->setFieldFormatting(array(
-                    'title' => '<a href=\"$Link\" class=\"grid-field__link-block\">$value ($CountForOverview)</a>'
-                ));
+            $columns->setFieldFormatting([
+                'title' => '<a href=\"$Link\" class=\"grid-field__link-block\">$value ($CountForOverview)</a>'
+            ]);
             $gridField->addExtraClass('all-reports-gridfield');
             $fields->push($gridField);
         }
 
-        $actions = new FieldList();
-        $form = new Form($this, "EditForm", $fields, $actions);
+        $actions = FieldList::create();
+        $form = Form::create($this, "EditForm", $fields, $actions);
         $form->addExtraClass(
             'panel panel--padded panel--scrollable cms-edit-form cms-panel-padded' . $this->BaseCSSClasses()
         );

--- a/code/ReportAdmin.php
+++ b/code/ReportAdmin.php
@@ -119,9 +119,7 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider
         }
 
         return $output
-            // Provide a good default for the reports order, otherwise this will be using sort by namespace
             ->sort('Title', 'ASC')
-            // Provide a good default for the data class, otherwise this will use the class of the first item in the list
             ->setDataClass(Report::class);
     }
 
@@ -250,14 +248,16 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider
                 GridFieldPaginator::create()
             );
 
+            $titleLabel = _t('SilverStripe\\Reports\\ReportAdmin.ReportTitle', 'Title');
+            $descriptionLabel = _t('SilverStripe\\Reports\\ReportAdmin.ReportDescription', 'Description');
+
             // Configure the filter header filter search form
             $generalField = BasicSearchContext::config()->get('general_search_field_name');
             $searchFieldList = FieldList::create([
                 HiddenField::create($generalField),
-                TextField::create('Title'),
-                TextField::create('Description'),
+                TextField::create('Title', $titleLabel),
+                TextField::create('Description', $descriptionLabel),
             ]);
-
             $searchContext = BasicSearchContext::create(Report::class);
             $searchContext->setFields($searchFieldList);
 
@@ -266,22 +266,16 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider
                 'Title',
                 'Description',
             ];
-
             foreach ($filters as $fieldName) {
                 $fieldFilter = PartialMatchFilter::create($fieldName);
-                $fieldFilter->setModifiers([
-                    // We want case-insensitive match to be consistent with other areas of the CMS
-                    'nocase',
-                ]);
                 $searchContext->addFilter($fieldFilter);
             }
-
             $filterHeader->setSearchContext($searchContext);
 
             $gridField = GridField::create('Reports', false, $this->Reports(), $gridFieldConfig);
             $columns->setDisplayFields(array(
-                'title' => _t('SilverStripe\\Reports\\ReportAdmin.ReportTitle', 'Title'),
-                'description' => _t('SilverStripe\\Reports\\ReportAdmin.ReportDescription', 'Description'),
+                'title' => $titleLabel,
+                'description' => $descriptionLabel,
             ));
 
             $columns->setFieldFormatting([

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5",
+        "silverstripe/framework": "^5.2",
         "silverstripe/admin": "^2",
         "silverstripe/versioned": "^2",
         "silverstripe/config": "^2",


### PR DESCRIPTION
# ENH Reports list filtering and pagination.

![Screenshot 2024-10-11 at 2 42 57 PM](https://github.com/user-attachments/assets/53f54748-2118-4779-b09a-2c8a4e18c892)

## Description

Minor quality of life improvements to the reports list in the Reports admin.

* filtering capability added
* pagination capability added
* description expose in the list as a new column
* minor code cleanup

## Manual testing steps

* just need a sample vanilla install as it should have some out of the box reports
* you may want to change the pagination limit to force the pagination to show even with small number of reports for testing purposes

## Issues
- https://github.com/silverstripe/silverstripe-reports/issues/196

## Pull request checklist

- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
