### PR TITLE
ENH Remove unnecessary TinyMCE-specific code.

### DIFF
--- a/code/ReportAdmin.php
+++ b/code/ReportAdmin.php
@@ -68,10 +68,6 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider
     public function init()
     {
         parent::init();
-
-        // Set custom options for TinyMCE specific to ReportAdmin
-        HTMLEditorConfig::get('cms')->setOption('content_css', project() . '/css/editor.css');
-
         Requirements::javascript('silverstripe/reports: client/dist/js/ReportAdmin.js');
     }
 

--- a/tests/behat/features/sitewidecontentreport.feature
+++ b/tests/behat/features/sitewidecontentreport.feature
@@ -12,7 +12,7 @@ Feature: Site wide content report
     When I am logged in as a member of "EDITOR" group
     And I go to "/admin/reports"
     And I follow "Site-wide content report"
-    
+
     # Show all Pages
     Then I should see "My page"
     And I should see "my-page"
@@ -25,7 +25,7 @@ Feature: Site wide content report
     When I go to "/admin/reports"
     And I follow "Site-wide content report"
     When I follow "My page"
-    Then I should see a ".tox-tinymce" element
+    Then I should see "My page" in the ".breadcrumbs-wrapper" element
 
     # Click on a file to open it
     When I go to "/admin/reports"


### PR DESCRIPTION
This was checking for app/css/editor.css which in most cases won't even exist and in the cases it does exist is probably already applied.

## Issue
- https://github.com/silverstripe/silverstripe-htmleditor-tinymce/issues/2