### PR TITLE
FIX Don't show external links report if queuedjobs not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ This module contains the API's for building Reports that are displayed in the
 Silverstripe backend.
 
 There are also a few CMS reports that comes out of the box:
+
 - A "Users, Groups and Permissions" report allowing administrators to get a quick overview of who has access to the CMS.
 - A "Site-wide content report" report allowing CMS users to get a quick overview of content across the site.
 - An "External broken links report" allowing users with permissions to track broken external links.
+
+> [!NOTE]
+> Note that for the "External broken links report" to show up you must install [`symbiote/silverstripe-queuedjobs`](https://github.com/symbiote/silverstripe-queuedjobs).
 
 ## Troubleshooting
 

--- a/code/ExternalLinks/Reports/BrokenExternalLinksReport.php
+++ b/code/ExternalLinks/Reports/BrokenExternalLinksReport.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Reports\ExternalLinks\Reports;
 
 use SilverStripe\Core\Convert;
+use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\Reports\ExternalLinks\Model\BrokenExternalPageTrackStatus;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\FormAction;
@@ -25,6 +26,14 @@ class BrokenExternalLinksReport extends Report
     public function title()
     {
         return _t(__CLASS__ . '.EXTERNALBROKENLINKS', "External broken links report");
+    }
+
+    public function canView($member = null)
+    {
+        if (!ModuleLoader::inst()->getManifest()->moduleExists('symbiote/silverstripe-queuedjobs')) {
+            return false;
+        }
+        return parent::canView($member);
     }
 
     public function columns()


### PR DESCRIPTION
## Issue

- https://github.com/silverstripe/silverstripe-reports/issues/214