### PR TITLE
ENH Disable sorting on queries where sort order doesn't matter

### DIFF
--- a/code/ExternalLinks/Model/BrokenExternalPageTrackStatus.php
+++ b/code/ExternalLinks/Model/BrokenExternalPageTrackStatus.php
@@ -68,6 +68,7 @@ class BrokenExternalPageTrackStatus extends DataObject implements i18nEntityProv
     {
         $pageIDs = $this
             ->getIncompleteTracks()
+            ->sort(null)
             ->column('PageID');
         if ($pageIDs) {
             return Versioned::get_by_stage(SiteTree::class, 'Stage')
@@ -140,6 +141,7 @@ class BrokenExternalPageTrackStatus extends DataObject implements i18nEntityProv
 
         // Setup all pages to test
         $pageIDs = Versioned::get_by_stage(SiteTree::class, 'Stage')
+            ->sort(null)
             ->column('ID');
         foreach ($pageIDs as $pageID) {
             $trackPage = BrokenExternalPageTrack::create();


### PR DESCRIPTION
Sorting queries can be slow, especially on large datasets and especially if indexes aren't optimised. We should avoid sorting when the sort order doesn't matter.


## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11833