### PR TITLE
MNT Update unit tests for PHP 8.5

### DIFF
--- a/tests/php/ReportAdminTest.php
+++ b/tests/php/ReportAdminTest.php
@@ -83,11 +83,9 @@ class ReportAdminTest extends FunctionalTest
         $reflector = new ReflectionClass($controller = ReportAdmin::create());
 
         $reportClass = $reflector->getProperty('reportClass');
-        $reportClass->setAccessible(true);
         $reportClass->setValue($controller, get_class($report));
 
         $reportObject = $reflector->getProperty('reportObject');
-        $reportObject->setAccessible(true);
         $reportObject->setValue($controller, $report);
 
         $controller->setRequest(Controller::curr()->getRequest());


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.
